### PR TITLE
Add token-based security

### DIFF
--- a/ert_storage/database.py
+++ b/ert_storage/database.py
@@ -1,9 +1,11 @@
 import os
 import sys
 from typing import Any, Callable, Type
+from fastapi import Depends
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from ert_storage.security import security
 
 
 ENV_RDBMS = "ERT_STORAGE_DATABASE_URL"
@@ -31,7 +33,7 @@ Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 
-async def get_db() -> Any:
+async def get_db(*, _: None = Depends(security)) -> Any:
     db = Session()
 
     # Make PostgreSQL return float8 columns with highest precision. If we don't

--- a/ert_storage/security.py
+++ b/ert_storage/security.py
@@ -1,0 +1,25 @@
+import os
+from typing import Optional
+from fastapi import Security, HTTPException, status
+from fastapi.security import APIKeyHeader
+
+
+DEFAULT_TOKEN = "hunter2"
+_security_header = APIKeyHeader(name="Token", auto_error=False)
+
+
+async def security(*, token: Optional[str] = Security(_security_header)) -> None:
+    if os.getenv("ERT_STORAGE_NO_TOKEN"):
+        return
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not authenticated"
+        )
+    real_token = os.getenv("ERT_STORAGE_TOKEN", DEFAULT_TOKEN)
+    if token == real_token:
+        # Success
+        return
+
+    # HTTP 403 is when the user has authorized themselves, but aren't allowed to
+    # access this resource
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token")

--- a/ert_storage/testing/testclient.py
+++ b/ert_storage/testing/testclient.py
@@ -13,6 +13,7 @@ from typing import (
 )
 from pprint import pformat
 from contextlib import contextmanager
+from fastapi import Depends
 from sqlalchemy.orm.session import Session
 from sqlalchemy.engine.base import Transaction
 from starlette.testclient import (
@@ -28,6 +29,8 @@ from starlette.testclient import (
 from sqlalchemy.orm import sessionmaker
 from graphene import Schema as GrapheneSchema
 from graphene.test import Client as GrapheneClient
+
+from ert_storage.security import security
 
 
 if TYPE_CHECKING:
@@ -268,7 +271,9 @@ def _override_get_db(session: sessionmaker) -> None:
         IS_POSTGRES,
     )
 
-    async def override_get_db() -> AsyncGenerator[Session, None]:
+    async def override_get_db(
+        *, _: None = Depends(security)
+    ) -> AsyncGenerator[Session, None]:
         db = session()
 
         # Make PostgreSQL return float8 columns with highest precision. If we don't

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,10 +2,11 @@ import pytest
 
 
 @pytest.fixture
-def client(ert_storage_client):
+def client(ert_storage_client, monkeypatch):
     """
-    Simple rename of ert_storage_client -> client
+    Simple rename of ert_storage_client -> client, with security off
     """
+    monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "1")
     return ert_storage_client
 
 

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -1,0 +1,46 @@
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from ert_storage.security import DEFAULT_TOKEN
+
+
+@pytest.fixture
+def client(ert_storage_client, monkeypatch):
+    """
+    Simple rename of ert_storage_client -> client
+    """
+    return ert_storage_client
+
+
+def test_auth_success(client, monkeypatch):
+    resp = client.post(
+        "/experiments", json={"name": "test"}, headers={"Token": DEFAULT_TOKEN}
+    )
+
+    token = "sxbqRhLoFVbzmG4y"
+    monkeypatch.setenv("ERT_STORAGE_TOKEN", token)
+    resp = client.post("/experiments", json={"name": "test"}, headers={"Token": token})
+
+
+def test_auth_fail(client, monkeypatch):
+    client.post(
+        "/experiments",
+        json={"name": "test"},
+        check_status_code=status.HTTP_403_FORBIDDEN,
+    )
+
+    client.post(
+        "/experiments",
+        json={"name": "test"},
+        headers={"Token": "Incorrect Token"},
+        check_status_code=status.HTTP_403_FORBIDDEN,
+    )
+
+    token = "sxbqRhLoFVbzmG4y"
+    monkeypatch.setenv("ERT_STORAGE_TOKEN", token)
+    client.post(
+        "/experiments",
+        json={"name": "test"},
+        headers={"Token": "Still Incorrect Token"},
+        check_status_code=status.HTTP_403_FORBIDDEN,
+    )


### PR DESCRIPTION
We now check for the `ERT_STORAGE_TOKEN`, for a HTTP header-based token.
If unset, defaults to `hunter2`, which we can use for development.

Resolves: #6 