### PR TITLE
Add GraphQL /gql endpoint

### DIFF
--- a/ert_storage/app.py
+++ b/ert_storage/app.py
@@ -2,8 +2,10 @@ import json
 from typing import Any
 from fastapi import FastAPI, Request, status
 from fastapi.responses import Response, RedirectResponse
+from starlette.graphql import GraphQLApp
 
-from ert_storage.endpoints import router
+from ert_storage.endpoints import router as endpoints_router
+from ert_storage.graphql import router as graphql_router
 
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -67,4 +69,5 @@ async def healthcheck() -> str:
     return "ALL OK!"
 
 
-app.include_router(router)
+app.include_router(endpoints_router)
+app.include_router(graphql_router)

--- a/ert_storage/database_schema.py
+++ b/ert_storage/database_schema.py
@@ -1,22 +1,13 @@
 from enum import Enum
-from typing import Any, Optional, Callable
+from typing import Any, Optional
 
 import sqlalchemy as sa
-from sqlalchemy.orm import relationship, backref
-from sqlalchemy.orm.collections import attribute_mapped_collection
+from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
-from sqlalchemy.ext.associationproxy import association_proxy
 
-from ert_storage.database import Base, IS_POSTGRES
+from ert_storage.database import Base
 
-
-if IS_POSTGRES:
-    FloatArray = sa.ARRAY(sa.FLOAT)
-    StringArray = sa.ARRAY(sa.String)
-
-else:
-    FloatArray = sa.PickleType
-    StringArray = sa.PickleType
+from ert_storage.ext.sqlalchemy_arrays import StringArray, FloatArray
 
 
 class RecordType(Enum):

--- a/ert_storage/ext/__init__.py
+++ b/ert_storage/ext/__init__.py
@@ -1,0 +1,3 @@
+"""
+Extensions to external library APIs
+"""

--- a/ert_storage/ext/graphene_sqlalchemy.py
+++ b/ert_storage/ext/graphene_sqlalchemy.py
@@ -1,0 +1,123 @@
+"""
+This module adds the SQLAlchemyMutation class, a graphene.Mutation whose
+output mirrors an SQLAlchemyObjectType. This allows us to create mutation that behave
+"""
+
+
+from collections import OrderedDict
+from typing import Any, Type, Iterable, Callable, Optional, TYPE_CHECKING, Dict
+
+from graphene_sqlalchemy import SQLAlchemyObjectType
+from graphene.types.mutation import MutationOptions
+from graphene.types.utils import yank_fields_from_attrs
+from graphene.types.interface import Interface
+from graphene.utils.get_unbound_function import get_unbound_function
+from graphene.utils.props import props
+from graphene.types.objecttype import ObjectTypeOptions
+from graphene import Field, Interface
+
+
+__all__ = ["SQLAlchemyObjectType", "SQLAlchemyMutation"]
+
+
+if TYPE_CHECKING:
+    from graphene_sqlalchemy.types.argument import Argument
+    import graphene.types.field
+
+
+class SQLAlchemyMutation(SQLAlchemyObjectType):
+    """
+    Object Type Definition (mutation field), appropriated from graphene.Mutation
+
+    SQLAlchemyMutation is a convenience type that helps us build a Field which
+    takes Arguments and returns a mutation Output SQLAlchemyObjectType.
+
+    Meta class options (optional):
+        resolver (Callable resolver method): Or ``mutate`` method on Mutation class. Perform data
+            change and return output.
+        arguments (Dict[str, graphene.Argument]): Or ``Arguments`` inner class with attributes on
+            Mutation class. Arguments to use for the mutation Field.
+        name (str): Name of the GraphQL type (must be unique in schema). Defaults to class
+            name.
+        description (str): Description of the GraphQL type in the schema. Defaults to class
+            docstring.
+        interfaces (Iterable[graphene.Interface]): GraphQL interfaces to extend with the payload
+            object. All fields from interface will be included in this object's schema.
+        fields (Dict[str, graphene.Field]): Dictionary of field name to Field. Not recommended to
+            use (prefer class attributes or ``Meta.output``).
+
+    """
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def __init_subclass_with_meta__(
+        cls,
+        interfaces: Iterable[Type[Interface]] = (),
+        resolver: Callable = None,
+        arguments: Dict[str, "Argument"] = None,
+        _meta: Optional[ObjectTypeOptions] = None,
+        **options: Any
+    ) -> None:
+        if not _meta:
+            _meta = MutationOptions(cls)
+
+        fields = {}
+
+        for interface in interfaces:
+            assert issubclass(interface, Interface), (
+                'All interfaces of {} must be a subclass of Interface. Received "{}".'
+            ).format(cls.__name__, interface)
+            fields.update(interface._meta.fields)
+
+        fields = OrderedDict()
+        for base in reversed(cls.__mro__):
+            fields.update(yank_fields_from_attrs(base.__dict__, _as=Field))
+
+        if not arguments:
+            input_class = getattr(cls, "Arguments", None)
+
+            if input_class:
+                arguments = props(input_class)
+            else:
+                arguments = {}
+
+        if not resolver:
+            mutate = getattr(cls, "mutate", None)
+            assert mutate, "All mutations must define a mutate method in it"
+            resolver = get_unbound_function(mutate)
+
+        if _meta.fields:
+            _meta.fields.update(fields)
+        else:
+            _meta.fields = fields
+
+        _meta.interfaces = interfaces
+        _meta.resolver = resolver
+        _meta.arguments = arguments
+
+        super(SQLAlchemyMutation, cls).__init_subclass_with_meta__(
+            _meta=_meta, **options
+        )
+
+    @classmethod
+    def Field(
+        cls,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        deprecation_reason: Optional[str] = None,
+        required: bool = False,
+        **kwargs: Any
+    ) -> "graphene.types.field.Field":
+        """ Mount instance of mutation Field. """
+        return Field(
+            cls,
+            args=cls._meta.arguments,
+            resolver=cls._meta.resolver,
+            name=name,
+            description=description or cls._meta.description,
+            deprecation_reason=deprecation_reason,
+            required=required,
+            **kwargs
+        )

--- a/ert_storage/ext/sqlalchemy_arrays.py
+++ b/ert_storage/ext/sqlalchemy_arrays.py
@@ -1,0 +1,44 @@
+"""
+This module adds thte FloatArray and StringArray column types. In Postgresql,
+both are native `sqlalchemy.ARRAY`s, while on SQLite, they are `PickleType`s.
+
+In order to have graphene_sqlalchemy dump the arrays as arrays and not strings,
+we need to subclass `PickleType`, and then use
+`convert_sqlalchemy_type.register` much in the same way that graphene_sqlalchemy
+does it internally for its other types.
+"""
+from typing import Optional, Type, Union
+import sqlalchemy as sa
+
+from ert_storage.database import IS_POSTGRES
+
+
+__all__ = ["FloatArray", "StringArray"]
+
+
+SQLAlchemyColumn = Union[sa.types.TypeEngine, Type[sa.types.TypeEngine]]
+FloatArray: SQLAlchemyColumn
+StringArray: SQLAlchemyColumn
+
+if IS_POSTGRES:
+    FloatArray = sa.ARRAY(sa.FLOAT)
+    StringArray = sa.ARRAY(sa.String)
+else:
+    FloatArray = type("FloatArray", (sa.PickleType,), dict(sa.PickleType.__dict__))
+    StringArray = type("StringArray", (sa.PickleType,), dict(sa.PickleType.__dict__))
+
+    import graphene
+    from graphene_sqlalchemy.converter import convert_sqlalchemy_type
+    from graphene_sqlalchemy.registry import Registry
+
+    @convert_sqlalchemy_type.register(StringArray)
+    def convert_column_to_string_array(
+        type: SQLAlchemyColumn, column: sa.Column, registry: Optional[Registry] = None
+    ) -> graphene.types.structures.Structure:
+        return graphene.List(graphene.String)
+
+    @convert_sqlalchemy_type.register(FloatArray)
+    def convert_column_to_float_array(
+        type: SQLAlchemyColumn, column: sa.Column, registry: Optional[Registry] = None
+    ) -> graphene.types.structures.Structure:
+        return graphene.List(graphene.Float)

--- a/ert_storage/graphql/__init__.py
+++ b/ert_storage/graphql/__init__.py
@@ -1,0 +1,61 @@
+from typing import Any, Optional
+from starlette.graphql import GraphQLApp
+from fastapi import APIRouter
+from ert_storage.database import sessionmaker, Session
+import graphene as gr
+from graphql.execution.base import ExecutionResult, ResolveInfo
+
+from ert_storage.graphql.ensembles import Ensemble, CreateEnsemble
+from ert_storage.graphql.experiments import Experiment, CreateExperiment
+from ert_storage import database_schema as ds
+
+
+class Mutations(gr.ObjectType):
+    create_experiment = CreateExperiment.Field()
+    create_ensemble = CreateEnsemble.Field(experiment_id=gr.ID(required=True))
+
+
+class Query(gr.ObjectType):
+    experiments = gr.List(Experiment)
+    experiment = gr.Field(Experiment, id=gr.ID(required=True))
+    ensemble = gr.Field(Ensemble, id=gr.ID(required=True))
+
+    @staticmethod
+    def resolve_experiments(root: None, info: ResolveInfo) -> ds.Experiment:
+        return Experiment.get_query(info).all()
+
+    @staticmethod
+    def resolve_experiment(root: None, info: ResolveInfo, id: str) -> ds.Experiment:
+        return Experiment.get_query(info).filter_by(id=id).one()
+
+    @staticmethod
+    def resolve_ensemble(root: None, info: ResolveInfo, id: str) -> ds.Ensemble:
+        return Ensemble.get_query(info).filter_by(id=id).one()
+
+
+class Schema(gr.Schema):
+    """
+    Extended graphene Schema class, where `execute` creates a database session
+    and passes it on further.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.override_session: Optional[sessionmaker] = None
+
+    def execute(self, *args: Any, **kwargs: Any) -> ExecutionResult:
+        kwargs.setdefault("context_value", {})
+        if self.override_session is not None:
+            session_obj = self.override_session()
+        else:
+            session_obj = Session()
+        with session_obj as session:
+            kwargs["context_value"]["session"] = session
+
+            return super().execute(*args, **kwargs)
+
+
+schema = Schema(query=Query, mutation=Mutations)
+graphql_app = GraphQLApp(schema=schema)
+router = APIRouter(tags=["graphql"])
+router.add_route("/gql", graphql_app)

--- a/ert_storage/graphql/ensembles.py
+++ b/ert_storage/graphql/ensembles.py
@@ -1,0 +1,46 @@
+from typing import List, Optional, TYPE_CHECKING
+import graphene as gr
+from graphene_sqlalchemy.utils import get_session
+
+from ert_storage.ext.graphene_sqlalchemy import SQLAlchemyObjectType, SQLAlchemyMutation
+from ert_storage import database_schema as ds
+
+
+if TYPE_CHECKING:
+    from graphql.execution.base import ResolveInfo
+    from ert_storage.graphql.experiments import Experiment
+
+
+class Ensemble(SQLAlchemyObjectType):
+    class Meta:
+        model = ds.Ensemble
+
+
+class CreateEnsemble(SQLAlchemyMutation):
+    class Meta:
+        model = ds.Ensemble
+
+    class Arguments:
+        parameters = gr.List(gr.String)
+
+    @staticmethod
+    def mutate(
+        root: Optional["Experiment"],
+        info: "ResolveInfo",
+        parameters: List[str],
+        experiment_id: Optional[str] = None,
+    ) -> ds.Ensemble:
+        db = get_session(info.context)
+
+        if experiment_id is not None:
+            experiment = db.query(ds.Experiment).get(experiment_id)
+        elif hasattr(root, "id"):
+            experiment = root
+        else:
+            raise ValueError("ID is required")
+
+        ensemble = ds.Ensemble(inputs=parameters, experiment=experiment)
+
+        db.add(ensemble)
+        db.commit()
+        return ensemble

--- a/ert_storage/graphql/experiments.py
+++ b/ert_storage/graphql/experiments.py
@@ -1,0 +1,37 @@
+from typing import TYPE_CHECKING
+import graphene as gr
+from graphene_sqlalchemy.utils import get_session
+
+from ert_storage.ext.graphene_sqlalchemy import SQLAlchemyObjectType, SQLAlchemyMutation
+from ert_storage.graphql.ensembles import CreateEnsemble
+from ert_storage import database_schema as ds
+
+
+if TYPE_CHECKING:
+    from graphql.execution.base import ResolveInfo
+
+
+class Experiment(SQLAlchemyObjectType):
+    class Meta:
+        model = ds.Experiment
+
+
+class CreateExperiment(SQLAlchemyMutation):
+    class Arguments:
+        name = gr.String()
+
+    class Meta:
+        model = ds.Experiment
+
+    create_ensemble = CreateEnsemble.Field()
+
+    @staticmethod
+    def mutate(root: None, info: "ResolveInfo", name: str) -> ds.Experiment:
+        db = get_session(info.context)
+
+        experiment = ds.Experiment(name=name)
+
+        db.add(experiment)
+        db.commit()
+
+        return experiment

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@ setup(
         "ert_storage._alembic.alembic",
         "ert_storage._alembic.alembic.versions",
         "ert_storage.endpoints",
+        "ert_storage.ext",
+        "ert_storage.graphql",
+        "ert_storage.json_schema",
     ],
     package_data={
         "ert_storage._alembic": [
@@ -40,11 +43,14 @@ setup(
         "async-generator; python_version < '3.7'",
         "azure-storage-blob",
         "fastapi",
+        "graphene",
+        "graphene-sqlalchemy>=2.0",
         "numpy",
         "pydantic",
         "python-multipart",
         "requests",
-        "sqlalchemy",
+        "sqlalchemy>=1.4",
+        "starlette==0.13.6",
         "uvicorn",
     ],
 )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,10 @@ from sqlalchemy.orm import sessionmaker
 
 
 class _TestClient(TestClient):
+    def __init__(self, *args, session: sessionmaker, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.session = session
+
     def get_check(self, *args, **kwargs):
         resp = self.get(*args, **kwargs)
         if resp.status_code != 200:
@@ -75,7 +79,7 @@ def client():
             raise
 
     app.dependency_overrides[get_db] = override_get_db
-    yield _TestClient(app)
+    yield _TestClient(app, session=TestSession)
 
     # teardown: rollback database to before the test.
     # For debugging change rollback to commit.

--- a/tests/integration/gql/__init__.py
+++ b/tests/integration/gql/__init__.py
@@ -1,0 +1,5 @@
+"""
+This module is named `gql` because the name `graphql` would conflict with
+the `graphql` package as pytest adds all subdirectories of `tests` directory to
+`sys.paths`.
+"""

--- a/tests/integration/gql/conftest.py
+++ b/tests/integration/gql/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.fixture
+def gql_client(client, monkeypatch):
+    from ert_storage.graphql import schema
+    from graphene.test import Client
+
+    monkeypatch.setattr(schema, "override_session", client.session)
+    yield Client(schema)

--- a/tests/integration/gql/test_ensembles.py
+++ b/tests/integration/gql/test_ensembles.py
@@ -1,0 +1,47 @@
+import uuid
+
+
+GET_ENSEMBLE = """\
+query($id: ID!) {
+  ensemble(id: $id) {
+    id
+    inputs
+  }
+}
+"""
+
+CREATE_ENSEMBLE = """\
+mutation create($experimentId: ID!, $params: [String]) {
+  createEnsemble(experimentId: $experimentId, parameters: $params) {
+    id
+  }
+}
+"""
+
+
+def test_get_ensemble(gql_client, simple_ensemble):
+    eparams = [rand_name() for _ in range(3)]
+    eid = simple_ensemble(eparams)
+    r = gql_client.execute(GET_ENSEMBLE, variable_values={"id": eid})
+
+    assert r["data"]["ensemble"]["id"] == str(eid)
+    assert r["data"]["ensemble"]["inputs"] == eparams
+
+
+def test_create_ensemble(gql_client, create_experiment):
+    experiment_id = create_experiment(rand_name())
+    eparams = [rand_name() for _ in range(8)]
+    r = gql_client.execute(
+        CREATE_ENSEMBLE,
+        variable_values={"experimentId": experiment_id, "params": eparams},
+    )
+    eid = r["data"]["createEnsemble"]["id"]
+
+    r = gql_client.execute(GET_ENSEMBLE, variable_values={"id": eid})
+
+    assert r["data"]["ensemble"]["id"] == eid
+    assert r["data"]["ensemble"]["inputs"] == eparams
+
+
+def rand_name():
+    return str(uuid.uuid4())

--- a/tests/integration/gql/test_experiments.py
+++ b/tests/integration/gql/test_experiments.py
@@ -1,0 +1,106 @@
+import uuid
+
+
+GET_EXPERIMENT = """\
+query($id: ID!) {
+  experiment(id: $id) {
+    name
+    id
+    ensembles {
+      id
+      inputs
+    }
+  }
+}
+"""
+
+GET_EXPERIMENTS = """\
+{
+  experiments {
+    id
+    name
+  }
+}
+"""
+
+CREATE_EXPERIMENT = """\
+mutation($name: String) {
+  createExperiment(name: $name) {
+    name
+    id
+  }
+}
+"""
+
+
+CREATE_EXPERIMENT_WITH_ENSEMBLE = """\
+mutation($name: String, $params: [String!]) {
+  createExperiment(name: $name) {
+    id
+    createEnsemble(parameters: $params) {
+      id
+    }
+  }
+}
+"""
+
+
+def test_get_single_experiment(gql_client, create_experiment):
+    ename = rand_name()
+    eid = create_experiment(ename)
+
+    r = gql_client.execute(
+        GET_EXPERIMENT,
+        variable_values={"id": eid},
+    )
+    assert r["data"]["experiment"]["id"] == str(eid)
+    assert r["data"]["experiment"]["name"] == ename
+
+
+def test_get_list_experiments(gql_client, create_experiment):
+    enames = [rand_name() for _ in range(5)]
+    eids = [str(create_experiment(ename)) for ename in enames]
+
+    r = gql_client.execute(GET_EXPERIMENTS)
+    actual_eids = {e["id"] for e in r["data"]["experiments"]}
+    actual_enames = {e["name"] for e in r["data"]["experiments"]}
+
+    assert len(r["data"]["experiments"]) >= 5
+    assert set(eids) <= actual_eids
+    assert set(enames) <= actual_enames
+
+
+def test_create_experiment(gql_client):
+    ename = rand_name()
+    r = gql_client.execute(CREATE_EXPERIMENT, variable_values={"name": ename})
+
+    eid = r["data"]["createExperiment"]["id"]
+    r = gql_client.execute(
+        GET_EXPERIMENT,
+        variable_values={"id": eid},
+    )
+    assert r["data"]["experiment"]["id"] == eid
+    assert r["data"]["experiment"]["name"] == ename
+
+
+def test_create_experiment_with_ensemble(gql_client):
+    ename = rand_name()
+    eparams = [rand_name() for _ in range(5)]
+    r = gql_client.execute(
+        CREATE_EXPERIMENT_WITH_ENSEMBLE,
+        variable_values={"name": ename, "params": eparams},
+    )
+
+    eid = r["data"]["createExperiment"]["id"]
+    r = gql_client.execute(
+        GET_EXPERIMENT,
+        variable_values={"id": eid},
+    )
+    assert r["data"]["experiment"]["id"] == eid
+    assert r["data"]["experiment"]["name"] == ename
+    assert len(r["data"]["experiment"]["ensembles"]) == 1
+    assert r["data"]["experiment"]["ensembles"][0]["inputs"] == eparams
+
+
+def rand_name():
+    return str(uuid.uuid4())


### PR DESCRIPTION
Resolves: #44 

This PR includes only endpoints for experiments and ensembles. I've deliberately left off records and observations as they seem to be considerably more difficult in terms of efficient data passing, and seem out of scope when the issue title is "Implement _basic_ graphql endpoint".

Besides, it could very well be that we'll never actually support uploading records and observations using GraphQL, and only permit querying for their IDs and similar metadata.