### PR TITLE
Migrate misfits

### DIFF
--- a/ert_storage/compute/__init__.py
+++ b/ert_storage/compute/__init__.py
@@ -1,0 +1,1 @@
+from .misfits import calculate_misfits_from_pandas

--- a/ert_storage/compute/misfits.py
+++ b/ert_storage/compute/misfits.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pandas as pd
+from uuid import UUID
+from typing import Any, Mapping, List, Optional
+
+
+def _calculate_misfit(
+    obs_value: np.ndarray, response_value: np.ndarray, obs_std: np.ndarray
+) -> List[float]:
+    difference = response_value - obs_value
+    misfit = (difference / obs_std) ** 2
+    return (misfit * np.sign(difference)).tolist()
+
+
+def calculate_misfits_from_pandas(
+    reponses_dict: Mapping[int, pd.DataFrame],
+    observation: pd.DataFrame,
+    summary_misfits: bool = False,
+) -> pd.DataFrame:
+    """
+    Compute misfits from reponses_dict (real_id, values in dataframe)
+    and observation
+    """
+    misfits_dict = {}
+    for realization_index in reponses_dict:
+        misfits_dict[realization_index] = _calculate_misfit(
+            observation["values"],
+            reponses_dict[realization_index].loc[observation.index].values.flatten(),
+            observation["errors"],
+        )
+
+    df = pd.DataFrame(data=misfits_dict, index=observation.index)
+    if summary_misfits:
+        df = pd.DataFrame([df.abs().sum(axis=0)], columns=df.columns, index=[0])
+    return df

--- a/ert_storage/endpoints/__init__.py
+++ b/ert_storage/endpoints/__init__.py
@@ -4,6 +4,7 @@ from .records import router as records_router
 from .experiments import router as experiments_router
 from .observations import router as observations_router
 from .updates import router as updates_router
+from .compute.misfits import router as misfits_router
 
 router = APIRouter()
 router.include_router(experiments_router)
@@ -11,3 +12,4 @@ router.include_router(ensembles_router)
 router.include_router(records_router)
 router.include_router(observations_router)
 router.include_router(updates_router)
+router.include_router(misfits_router)

--- a/ert_storage/endpoints/compute/misfits.py
+++ b/ert_storage/endpoints/compute/misfits.py
@@ -1,0 +1,84 @@
+import numpy as np
+import pandas as pd
+from uuid import UUID
+from typing import Any, Optional, List
+import sqlalchemy as sa
+from fastapi.responses import Response
+from fastapi import APIRouter, Depends, HTTPException, status
+from ert_storage.database import Session, get_db
+from ert_storage import database_schema as ds, json_schema as js
+from ert_storage.compute import calculate_misfits_from_pandas, misfits
+
+router = APIRouter(tags=["misfits"])
+
+
+@router.get(
+    "/compute/misfits",
+    responses={
+        status.HTTP_200_OK: {
+            "content": {"application/x-dataframe": {}},
+            "description": "Return misfits as csv, where columns are realizations.",
+        }
+    },
+)
+async def get_response_misfits(
+    *,
+    db: Session = Depends(get_db),
+    ensemble_id: UUID,
+    response_name: str,
+    realization_index: Optional[int] = None,
+    summary_misfits: bool = False,
+) -> Response:
+    """
+    Compute univariate misfits for response(s)
+    """
+
+    ensemble = db.query(ds.Ensemble).filter_by(id=ensemble_id).one()
+    reponse_query = (
+        db.query(ds.Record)
+        .filter_by(
+            ensemble_pk=ensemble.pk,
+            name=response_name,
+            _record_type=1,
+        )
+        .filter(ds.Record.observations != None)
+    )
+    if realization_index is not None:
+        responses = [reponse_query.filter_by(realization_index=realization_index).one()]
+    else:
+        responses = reponse_query.all()
+
+    observation_df = None
+    response_dict = {}
+    for response in responses:
+        data_df = pd.DataFrame(response.f64_matrix.content)
+        labels = response.f64_matrix.labels
+        if labels is not None:
+            data_df.columns = labels[0]
+            data_df.index = labels[1]
+        response_dict[response.realization_index] = data_df.copy()
+        if observation_df is None:
+            # currently we expect only a single observation object, while
+            # later in the future this might change
+            obs = response.observations[0]
+            observation_df = pd.DataFrame(
+                data={"values": obs.values, "errors": obs.errors}, index=obs.x_axis
+            )
+
+    try:
+        result_df = calculate_misfits_from_pandas(
+            response_dict, observation_df, summary_misfits
+        )
+    except Exception as misfits_exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": f"Unable to compute misfits: {misfits_exc}",
+                "name": response_name,
+                "ensemble_id": str(ensemble_id),
+            },
+        )
+    return Response(
+        content=result_df.to_csv().encode(),
+        media_type="application/x-dataframe",
+    )

--- a/ert_storage/ext/graphene_sqlalchemy.py
+++ b/ert_storage/ext/graphene_sqlalchemy.py
@@ -119,7 +119,7 @@ class SQLAlchemyMutation(SQLAlchemyObjectType):
         required: bool = False,
         **kwargs: Any
     ) -> "graphene.types.field.Field":
-        """ Mount instance of mutation Field. """
+        """Mount instance of mutation Field."""
         return Field(
             cls,
             args=cls._meta.arguments,

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(
         "ert_storage._alembic.alembic",
         "ert_storage._alembic.alembic.versions",
         "ert_storage.endpoints",
+        "ert_storage.endpoints.compute",
+        "ert_storage.compute",
         "ert_storage.ext",
         "ert_storage.graphql",
         "ert_storage.json_schema",

--- a/tests/integration/compute/test_misfits_endpoints.py
+++ b/tests/integration/compute/test_misfits_endpoints.py
@@ -1,0 +1,86 @@
+import io
+from fastapi import params
+import numpy as np
+from numpy.testing import assert_array_equal
+import pandas as pd
+
+
+OBSERVATION = (
+    "FOPR",
+    {"values": [1, 2, 3], "errors": [0.1, 0.2, 0.3], "x_axis": ["C", "E", "H"]},
+)
+
+
+def test_misfits_with_labels(client, create_experiment, create_ensemble):
+    experiment_id = create_experiment("test_ensembles")
+    ensemble_id = create_ensemble(experiment_id=experiment_id)
+    # post observation
+    name, obs = OBSERVATION
+    obs_id = client.post(
+        f"/experiments/{experiment_id}/observations",
+        json=dict(
+            name=name,
+            values=obs["values"],
+            errors=obs["errors"],
+            x_axis=obs["x_axis"],
+        ),
+    ).json()["id"]
+
+    # 5 realizations of 8 values each
+    matrices = np.random.rand(5, 8)
+
+    data_df = {
+        id_real: pd.DataFrame(
+            matrix,
+            columns=[f"{id_real}"],
+            index=["A", "B", "C", "D", "E", "F", "G", "H"],
+        )
+        for id_real, matrix in enumerate(matrices)
+    }
+
+    # post responses with the corresponding observation
+    for id_real in data_df:
+        resp = client.post(
+            f"/ensembles/{ensemble_id}/records/{name}/matrix",
+            data=data_df[id_real].to_csv().encode(),
+            headers={"content-type": "application/x-dataframe"},
+            params=dict(realization_index=id_real),
+        )
+        client.post(
+            f"/ensembles/{ensemble_id}/records/{name}/observations",
+            json=[obs_id],
+            params=dict(realization_index=id_real),
+        )
+    # get all realizations of the univariate misfits
+    resp = client.get(
+        "/compute/misfits",
+        params=dict(ensemble_id=str(ensemble_id), response_name=name),
+    )
+    stream = io.BytesIO(resp.content)
+    misfits_df = pd.read_csv(stream, index_col=0, float_precision="round_trip")
+    assert misfits_df.shape == (3, 5)
+    assert_array_equal(misfits_df.index, obs["x_axis"])
+
+    # get summary misfits for all realizations
+    resp = client.get(
+        "/compute/misfits",
+        params=dict(
+            ensemble_id=str(ensemble_id), response_name=name, summary_misfits=True
+        ),
+    )
+    stream = io.BytesIO(resp.content)
+    misfits_df = pd.read_csv(stream, index_col=0, float_precision="round_trip")
+    assert misfits_df.shape == (1, 5)
+
+    # get realization #4 univariate misfits
+    resp = client.get(
+        "/compute/misfits",
+        params=dict(
+            ensemble_id=str(ensemble_id), response_name=name, realization_index=4
+        ),
+    )
+    stream = io.BytesIO(resp.content)
+    misfits_df = pd.read_csv(stream, index_col=0, float_precision="round_trip")
+
+    assert_array_equal(misfits_df.index, obs["x_axis"])
+    assert misfits_df.shape == (3, 1)

--- a/tests/unit/compute/test_misfits.py
+++ b/tests/unit/compute/test_misfits.py
@@ -1,0 +1,144 @@
+from numpy.lib.npyio import loads
+import pandas as pd
+import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_array_less
+from ert_storage.compute import calculate_misfits_from_pandas, misfits
+
+# randomly generated 8 response values distributed in 5 realizations
+responses_values = [
+    [0.625, 0.44, 0.651, 0.373, 0.341, 0.265, 0.82, 0.181],
+    [0.525, 0.989, 0.757, 0.025, 0.35, 0.823, 0.664, 0.256],
+    [0.103, 0.322, 0.77, 0.101, 0.135, 0.741, 0.901, 0.415],
+    [0.825, 0.312, 0.271, 0.285, 0.768, 0.759, 0.065, 0.199],
+    [0.53, 0.954, 0.23, 0.582, 0.106, 0.173, 0.06, 0.951],
+]
+
+# pre-computed univariate misfits on 3 observation points
+univariate_misfits_results = {
+    0: [-12.1801, -68.8070, -88.2973],
+    1: [-5.9049, -68.0625, -83.6615],
+    2: [-5.2900, -86.9556, -74.24694],
+    3: [
+        -53.1440,
+        -37.9456,
+        -87.1733,
+    ],
+    4: [-59.2900, -89.6809, -46.6489],
+}
+
+summary_misfits_results = [
+    169.2845,
+    157.6289,
+    166.4926,
+    178.2630,
+    195.6198,
+]
+
+observation = {
+    "values": [1, 2, 3],
+    "errors": [0.1, 0.2, 0.3],
+    "x_axis": ["C", "E", "H"],
+}
+
+
+def _get_dummy_response_df():
+    return pd.DataFrame(
+        np.random.rand(8), index=["A", "B", "C", "D", "E", "F", "G", "H"]
+    )
+
+
+def _get_dummy_observation_df():
+    return pd.DataFrame(
+        data={"values": observation["values"], "errors": observation["errors"]},
+        index=observation["x_axis"],
+    )
+
+
+def test_misfits_computation():
+    response_dict = {}
+    for realization_index, values in enumerate(responses_values):
+        response_dict[realization_index] = pd.DataFrame(
+            values, index=["A", "B", "C", "D", "E", "F", "G", "H"]
+        )
+
+    observation_df = _get_dummy_observation_df()
+
+    misfits_df = calculate_misfits_from_pandas(
+        response_dict, observation_df, summary_misfits=False
+    )
+
+    for id_real in univariate_misfits_results:
+        assert_array_almost_equal(
+            univariate_misfits_results[id_real],
+            misfits_df[id_real].values.flatten(),
+            decimal=4,
+        )
+
+    misfits_df = calculate_misfits_from_pandas(
+        response_dict, observation_df, summary_misfits=True
+    )
+
+    assert_array_almost_equal(
+        summary_misfits_results,
+        misfits_df.values.flatten(),
+        decimal=4,
+    )
+
+
+def test_misfits_observations_match_response_values():
+    # response values are the same as observed values we expect zero misfits
+    data_df = _get_dummy_response_df()
+    observation_df = _get_dummy_observation_df()
+    # set values to match observations
+    data_df.loc[observation["x_axis"], 0] = observation_df["values"].values
+
+    misfits_df = calculate_misfits_from_pandas(
+        {0: data_df}, observation_df, summary_misfits=False
+    )
+
+    assert_array_almost_equal(
+        np.zeros(3),
+        misfits_df.values.flatten(),
+        decimal=4,
+    )
+
+
+def test_misfits_increasing_observation_error():
+    # increasing erros should provide lower values of misfits
+    data_df = _get_dummy_response_df()
+    observation_df = _get_dummy_observation_df()
+
+    misfits_increased_error = {}
+    for idx in range(3):
+        # increase the error
+        observation_df["errors"] += 1
+        misfits_increased_error[idx] = (
+            calculate_misfits_from_pandas(
+                {0: data_df}, observation_df, summary_misfits=False
+            )
+            .abs()  # required as univariate misfits now come with a sign
+            .values.flatten()
+        )
+    assert_array_less(misfits_increased_error[1], misfits_increased_error[0])
+    assert_array_less(misfits_increased_error[2], misfits_increased_error[1])
+
+
+def test_misfits_increasing_response_values():
+    # increasing response values compared to observation mean should
+    # provide higher values of misfits
+    data_df = _get_dummy_response_df()
+    observation_df = _get_dummy_observation_df()
+
+    misfits_increased_responses = {}
+    for idx in range(3):
+        # set response values as observation values and add a constant
+        data_df.loc[observation["x_axis"], 0] = observation_df["values"] + idx
+        misfits_increased_responses[idx] = (
+            calculate_misfits_from_pandas(
+                {0: data_df}, observation_df, summary_misfits=False
+            )
+            .abs()  # required as univariate misfits now come with a sign
+            .values.flatten()
+        )
+    assert_array_less(misfits_increased_responses[0], misfits_increased_responses[1])
+    assert_array_less(misfits_increased_responses[1], misfits_increased_responses[2])


### PR DESCRIPTION
Resolve #43 

The current plan is to:
- [x] make observation endpoints (post, get) on record in order to add observation (via ids) to existing record
- [x] make a compute endpoint
- [x] add summary misfits row to the response csv
- [x] add compute to `setup.py`
- [x] add `__init__.py` for compute endpoint
- [x] add fixed misfits test data