### PR TITLE
Add pr test against komodo

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -1,0 +1,16 @@
+
+copy_test_files () {
+    cp -r $CI_SOURCE_ROOT/tests $CI_TEST_ROOT/tests
+}
+
+install_test_dependencies () {
+    pip install .[test]
+}
+
+install_package () {
+    pip install . --no-deps
+}
+
+start_tests () {
+    pytest -k "not test_typing"
+}


### PR DESCRIPTION
Now that ert-storage has been introduced to komodo, we can have a ci-pipeline running the ert-storage tests with the libraries included in komodo.