### PR TITLE
Add ERT_STORAGE_NO_ROLLBACK envvar for testing

### DIFF
--- a/.github/workflows/postgres_no_rollback.yml
+++ b/.github/workflows/postgres_no_rollback.yml
@@ -1,0 +1,53 @@
+name: PostgreSQL Storage CI w/ no rollback
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.9]
+
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:10.8
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+        - 5432/tcp
+      
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version  }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: |
+          pip install -e .[test,postgres]
+
+      - name: Run tests
+        run: |
+          ert-storage alembic upgrade head
+          pytest tests -vv
+        env:
+          ERT_STORAGE_DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres
+          ERT_STORAGE_NO_ROLLBACK: 1

--- a/README.md
+++ b/README.md
@@ -186,4 +186,15 @@ export ERT_STORAGE_AZURE_CONNECTION_STRING="DefaultEndpointsProtocol=http;Accoun
 
 # Development
 For development, install the `test` extras `pip install ert-storage[test]`,
-which installs `black`, `pytest` and `mypy`. Run tests using `pytest`
+which installs `black`, `pytest` and `mypy`. Run tests using `pytest`.
+
+All integration tests must be able to pass when using a non-empty production
+database. In practice that means that each test needs to create a unique
+"experiment".
+
+During test debugging it might be helpful to have the tests persist data in the
+database. The following environment variable tells ERT Storage not to rollback the data after each test.
+
+``` sh
+export ERT_STORAGE_NO_ROLLBACK=1
+```

--- a/tests/integration/test_experiments.py
+++ b/tests/integration/test_experiments.py
@@ -51,6 +51,7 @@ def test_ensemble_size(client, create_experiment, create_ensemble):
 
 
 def test_delete_experiment(client, create_experiment, create_ensemble):
+    num_experiments_before_test = len(client.get("/experiments").json())
     experiment_id = create_experiment("1")
 
     ensemble_id = create_ensemble(experiment_id, ["param1", "param2"])
@@ -88,7 +89,7 @@ def test_delete_experiment(client, create_experiment, create_ensemble):
         )
     observations = client.get(f"/experiments/{experiment_id}/observations").json()
     client.delete(f"/experiments/{experiment_id}")
-    assert len(client.get(f"/experiments").json()) == 0
+    assert len(client.get(f"/experiments").json()) == num_experiments_before_test
     for obs in observations:
         resp = client.get(f"/observations/{obs['id']}", check_status_code=None)
         assert resp.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
Setting `ERT_STORAGE_NO_ROLLBACK` will stop tests performing rollbacks. This is useful in development when creating a simple database, and also making sure that trivial unique constraints don't cause errors.

Resolve: #63 