### PR TITLE
Transpose response before computing misfits

### DIFF
--- a/ert_storage/compute/misfits.py
+++ b/ert_storage/compute/misfits.py
@@ -25,11 +25,11 @@ def calculate_misfits_from_pandas(
     for realization_index in reponses_dict:
         misfits_dict[realization_index] = _calculate_misfit(
             observation["values"],
-            reponses_dict[realization_index].loc[observation.index].values.flatten(),
+            reponses_dict[realization_index].loc[:, observation.index].values.flatten(),
             observation["errors"],
         )
 
     df = pd.DataFrame(data=misfits_dict, index=observation.index)
     if summary_misfits:
         df = pd.DataFrame([df.abs().sum(axis=0)], columns=df.columns, index=[0])
-    return df
+    return df.T

--- a/ert_storage/endpoints/compute/misfits.py
+++ b/ert_storage/endpoints/compute/misfits.py
@@ -56,7 +56,7 @@ async def get_response_misfits(
         if labels is not None:
             data_df.columns = labels[0]
             data_df.index = labels[1]
-        response_dict[response.realization_index] = data_df.copy()
+        response_dict[response.realization_index] = data_df
         if observation_df is None:
             # currently we expect only a single observation object, while
             # later in the future this might change

--- a/tests/integration/compute/test_misfits_endpoints.py
+++ b/tests/integration/compute/test_misfits_endpoints.py
@@ -31,9 +31,9 @@ def test_misfits_with_labels(client, create_experiment, create_ensemble):
 
     data_df = {
         id_real: pd.DataFrame(
-            matrix,
-            columns=[f"{id_real}"],
-            index=["A", "B", "C", "D", "E", "F", "G", "H"],
+            [matrix],
+            index=[f"{id_real}"],
+            columns=["A", "B", "C", "D", "E", "F", "G", "H"],
         )
         for id_real, matrix in enumerate(matrices)
     }
@@ -58,8 +58,8 @@ def test_misfits_with_labels(client, create_experiment, create_ensemble):
     )
     stream = io.BytesIO(resp.content)
     misfits_df = pd.read_csv(stream, index_col=0, float_precision="round_trip")
-    assert misfits_df.shape == (3, 5)
-    assert_array_equal(misfits_df.index, obs["x_axis"])
+    assert misfits_df.shape == (5, 3)
+    assert_array_equal(misfits_df.columns, obs["x_axis"])
 
     # get summary misfits for all realizations
     resp = client.get(
@@ -70,7 +70,7 @@ def test_misfits_with_labels(client, create_experiment, create_ensemble):
     )
     stream = io.BytesIO(resp.content)
     misfits_df = pd.read_csv(stream, index_col=0, float_precision="round_trip")
-    assert misfits_df.shape == (1, 5)
+    assert misfits_df.shape == (5, 1)
 
     # get realization #4 univariate misfits
     resp = client.get(
@@ -82,5 +82,5 @@ def test_misfits_with_labels(client, create_experiment, create_ensemble):
     stream = io.BytesIO(resp.content)
     misfits_df = pd.read_csv(stream, index_col=0, float_precision="round_trip")
 
-    assert_array_equal(misfits_df.index, obs["x_axis"])
-    assert misfits_df.shape == (3, 1)
+    assert_array_equal(misfits_df.columns, obs["x_axis"])
+    assert misfits_df.shape == (1, 3)

--- a/tests/unit/compute/test_misfits.py
+++ b/tests/unit/compute/test_misfits.py
@@ -43,7 +43,7 @@ observation = {
 
 def _get_dummy_response_df():
     return pd.DataFrame(
-        np.random.rand(8), index=["A", "B", "C", "D", "E", "F", "G", "H"]
+        [np.random.rand(8)], columns=["A", "B", "C", "D", "E", "F", "G", "H"]
     )
 
 
@@ -58,7 +58,7 @@ def test_misfits_computation():
     response_dict = {}
     for realization_index, values in enumerate(responses_values):
         response_dict[realization_index] = pd.DataFrame(
-            values, index=["A", "B", "C", "D", "E", "F", "G", "H"]
+            [values], columns=["A", "B", "C", "D", "E", "F", "G", "H"]
         )
 
     observation_df = _get_dummy_observation_df()
@@ -70,7 +70,7 @@ def test_misfits_computation():
     for id_real in univariate_misfits_results:
         assert_array_almost_equal(
             univariate_misfits_results[id_real],
-            misfits_df[id_real].values.flatten(),
+            misfits_df.loc[id_real].values.flatten(),
             decimal=4,
         )
 
@@ -90,7 +90,7 @@ def test_misfits_observations_match_response_values():
     data_df = _get_dummy_response_df()
     observation_df = _get_dummy_observation_df()
     # set values to match observations
-    data_df.loc[observation["x_axis"], 0] = observation_df["values"].values
+    data_df.loc[0, observation["x_axis"]] = observation_df["values"].values
 
     misfits_df = calculate_misfits_from_pandas(
         {0: data_df}, observation_df, summary_misfits=False
@@ -132,7 +132,7 @@ def test_misfits_increasing_response_values():
     misfits_increased_responses = {}
     for idx in range(3):
         # set response values as observation values and add a constant
-        data_df.loc[observation["x_axis"], 0] = observation_df["values"] + idx
+        data_df.loc[0, observation["x_axis"]] = observation_df["values"] + idx
         misfits_increased_responses[idx] = (
             calculate_misfits_from_pandas(
                 {0: data_df}, observation_df, summary_misfits=False


### PR DESCRIPTION
Since records data come as `x_axis` being the columns we need to transpose it before computing misfits.