### PR TITLE
Bump Starlette version to 0.14.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "python-multipart",
         "requests",
         "sqlalchemy>=1.4",
-        "starlette==0.13.6",
+        "starlette==0.14.2",
         "uvicorn",
     ],
 )


### PR DESCRIPTION
FastAPI has bumped Starlette to 0.14.2 from 0.13.6 some time ago. We're
following suit.