### PR TITLE
Specify UUID cache_ok

### DIFF
--- a/src/ert_storage/ext/uuid.py
+++ b/src/ert_storage/ext/uuid.py
@@ -21,6 +21,7 @@ class UUID(TypeDecorator):
     """
 
     impl = CHAR
+    cache_ok = True
 
     def load_dialect_impl(self, dialect: Dialect) -> Any:
         if dialect.name == "postgresql":


### PR DESCRIPTION
SQLAlchemy complains about cache_ok not existing in UUID and spamming me with warnings. We tell it that UUID is cacheable and that it's all fine.