### PR TITLE
Explicitly specify testkomodo.sh testing packages

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -4,7 +4,7 @@ copy_test_files () {
 }
 
 install_test_dependencies () {
-    pip install .[test]
+    pip install black pytest
 }
 
 install_package () {


### PR DESCRIPTION
`pip install .[test]` installs `ert-storage` _and_ all of its primary dependencies. We _really_ don't want this. Instead, change it to install only `black` and `pytest`.