### PR TITLE
Repurpose x-dataframe mimetype as pickled pd dataframes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "graphene-sqlalchemy>=2.0",
         "numpy",
         "pandas",
+        "pyarrow",
         "pydantic",
         "python-multipart",
         "requests",

--- a/src/ert_storage/endpoints/compute/misfits.py
+++ b/src/ert_storage/endpoints/compute/misfits.py
@@ -18,7 +18,7 @@ router = APIRouter(tags=["misfits"])
     "/compute/misfits",
     responses={
         status.HTTP_200_OK: {
-            "content": {"application/x-dataframe": {}},
+            "content": {"text/csv": {}},
             "description": "Return misfits as csv, where columns are realizations.",
         }
     },

--- a/tests/integration/compute/test_misfits_endpoints.py
+++ b/tests/integration/compute/test_misfits_endpoints.py
@@ -43,7 +43,7 @@ def test_misfits_with_labels(client, create_experiment, create_ensemble):
         resp = client.post(
             f"/ensembles/{ensemble_id}/records/{name}/matrix",
             data=data_df[id_real].to_csv().encode(),
-            headers={"content-type": "application/x-dataframe"},
+            headers={"content-type": "text/csv"},
             params=dict(realization_index=id_real),
         )
         client.post(

--- a/tests/integration/gql/test_responses.py
+++ b/tests/integration/gql/test_responses.py
@@ -64,7 +64,7 @@ def test_get_gql_response(client, create_experiment, create_ensemble):
             client.post(
                 f"/ensembles/{ensemble_id}/records/{resp_name}/matrix",
                 data=data_df[id_real].to_csv().encode(),
-                headers={"content-type": "application/x-dataframe"},
+                headers={"content-type": "text/csv"},
                 params={"realization_index": id_real},
             )
             for resp_name in RESPONSE_NAMES


### PR DESCRIPTION
In order to have no information loss when uploading a dataframe to ert-storage we have to avoid using csv. This pr resolves this by pickling the dataframe and uploading it directly. Thus repurposing the application/x-dataframe mimetype for pickled dataframes.

This new feature is up for debate. 