### PR TITLE
Allow many-to-one semantics in record_info

### DIFF
--- a/src/ert_storage/database_schema/ensemble.py
+++ b/src/ert_storage/database_schema/ensemble.py
@@ -26,6 +26,7 @@ class Ensemble(Base, UserdataField):
         foreign_keys="[RecordInfo.ensemble_pk]",
         cascade="all, delete-orphan",
         lazy="dynamic",
+        back_populates="ensemble",
     )
     experiment_pk = sa.Column(
         sa.Integer, sa.ForeignKey("experiment.pk"), nullable=False


### PR DESCRIPTION
Resolves #134 

Add back_populates to record_info to allow many-to-one semantics.