### PR TITLE
Revert "lazy load database configuration"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         ],
         "azure": [
             "aiohttp",
-            "azure-storage-blob",
+            "azure-storage-blob<12.9",
         ],
     },
     install_requires=[

--- a/src/ert_storage/__main__.py
+++ b/src/ert_storage/__main__.py
@@ -44,7 +44,7 @@ def run_alembic(args: List[str]) -> None:
     """
     Forward arguments to alembic
     """
-    from alembic.config import main
+    from alembic.config import main as alembic_main
 
     dbkey = "ERT_STORAGE_DATABASE_URL"
     dburl = os.getenv(dbkey)
@@ -67,7 +67,7 @@ def run_alembic(args: List[str]) -> None:
     ]
 
     try:
-        main(argv=argv, prog="ert-storage alembic")
+        alembic_main(argv=argv, prog="ert-storage alembic")
     except FileNotFoundError as exc:
         if os.path.basename(exc.filename) == "script.py.mako":
             sys.exit(

--- a/src/ert_storage/__main__.py
+++ b/src/ert_storage/__main__.py
@@ -44,7 +44,7 @@ def run_alembic(args: List[str]) -> None:
     """
     Forward arguments to alembic
     """
-    from alembic.config import main as alembic_main
+    from alembic.config import main
 
     dbkey = "ERT_STORAGE_DATABASE_URL"
     dburl = os.getenv(dbkey)
@@ -67,7 +67,7 @@ def run_alembic(args: List[str]) -> None:
     ]
 
     try:
-        alembic_main(argv=argv, prog="ert-storage alembic")
+        main(argv=argv, prog="ert-storage alembic")
     except FileNotFoundError as exc:
         if os.path.basename(exc.filename) == "script.py.mako":
             sys.exit(

--- a/src/ert_storage/_alembic/alembic/env.py
+++ b/src/ert_storage/_alembic/alembic/env.py
@@ -6,7 +6,7 @@ from sqlalchemy import pool
 
 from alembic import context
 
-from ert_storage.database import database_config
+from ert_storage.database import ENV_RDBMS
 from ert_storage.database_schema import Base
 
 # this is the Alembic Config object, which provides
@@ -43,7 +43,7 @@ def run_migrations_offline():
     """
     # Alembic uses sprintf somewhere. Escape the '%'s so that alembic doesn't
     # think they're part of the format string.
-    url = os.environ[database_config.ENV_RDBMS].replace("%", "%%")
+    url = os.environ[ENV_RDBMS].replace("%", "%%")
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -64,7 +64,7 @@ def run_migrations_online():
     """
     # Alembic uses sprintf somewhere. Escape the '%'s so that alembic doesn't
     # think they're part of the format string.
-    url = os.environ[database_config.ENV_RDBMS].replace("%", "%%")
+    url = os.environ[ENV_RDBMS].replace("%", "%%")
 
     config.set_section_option(config.config_ini_section, "sqlalchemy.url", str(url))
     connectable = engine_from_config(

--- a/src/ert_storage/app.py
+++ b/src/ert_storage/app.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Any
 from fastapi import FastAPI, Request, status
 from fastapi.responses import Response, RedirectResponse
+from starlette.graphql import GraphQLApp
 
 from ert_storage.endpoints import router as endpoints_router
 from ert_storage.graphql import router as graphql_router
@@ -50,13 +51,13 @@ app = FastAPI(
 
 @app.on_event("startup")
 async def initialize_database() -> None:
-    from ert_storage.database import database_config
+    from ert_storage.database import engine, IS_SQLITE, HAS_AZURE_BLOB_STORAGE
     from ert_storage.database_schema import Base
 
-    if database_config.IS_SQLITE:
+    if IS_SQLITE:
         # Our SQLite backend doesn't support migrations, so create the database on the fly.
-        Base.metadata.create_all(bind=database_config.engine)
-    if database_config.HAS_AZURE_BLOB_STORAGE:
+        Base.metadata.create_all(bind=engine)
+    if HAS_AZURE_BLOB_STORAGE:
         from ert_storage.database import create_container_if_not_exist
 
         await create_container_if_not_exist()

--- a/src/ert_storage/database.py
+++ b/src/ert_storage/database.py
@@ -2,81 +2,45 @@ import os
 from typing import Any
 from fastapi import Depends
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.orm import sessionmaker
 from ert_storage.security import security
 
 
-class DatabaseConfig:
-    def __init__(self) -> None:
-        self.ENV_RDBMS = "ERT_STORAGE_DATABASE_URL"
-        self.ENV_BLOB = "ERT_STORAGE_AZURE_CONNECTION_STRING"
-        self.ENV_BLOB_CONTAINER = "ERT_STORAGE_AZURE_BLOB_CONTAINER"
-        self._session = None
-        self._engine = None
-
-    def get_env_rdbms(self) -> str:
-        if not self.ENV_RDBMS_AVAILABLE:
-            raise EnvironmentError(f"Environment variable '{self.ENV_RDBMS}' not set")
-        return os.environ[self.ENV_RDBMS]
-
-    @property
-    def ENV_RDBMS_AVAILABLE(self) -> bool:
-        return self.ENV_RDBMS in os.environ
-
-    @property
-    def URI_RDBMS(self) -> str:
-        return self.get_env_rdbms()
-
-    @property
-    def IS_SQLITE(self) -> bool:
-        return self.URI_RDBMS.startswith("sqlite")
-
-    @property
-    def IS_POSTGRES(self) -> bool:
-        return self.URI_RDBMS.startswith("postgres")
-
-    @property
-    def HAS_AZURE_BLOB_STORAGE(self) -> bool:
-        return self.ENV_BLOB in os.environ
-
-    @property
-    def BLOB_CONTAINER(self) -> str:
-        return os.getenv(self.ENV_BLOB_CONTAINER, "ert")
-
-    @property
-    def engine(self) -> Engine:
-        if self._engine is None:
-            if self.IS_SQLITE:
-                self._engine = create_engine(
-                    self.URI_RDBMS, connect_args={"check_same_thread": False}
-                )
-            else:
-                self._engine = create_engine(
-                    self.URI_RDBMS, pool_size=50, max_overflow=100
-                )
-        return self._engine
-
-    @property
-    def Session(self) -> sessionmaker:
-        if self._session is None:
-            self._session = sessionmaker(
-                autocommit=False, autoflush=False, bind=self.engine
-            )
-        return self._session
+ENV_RDBMS = "ERT_STORAGE_DATABASE_URL"
+ENV_BLOB = "ERT_STORAGE_AZURE_CONNECTION_STRING"
+ENV_BLOB_CONTAINER = "ERT_STORAGE_AZURE_BLOB_CONTAINER"
 
 
-database_config = DatabaseConfig()
+def get_env_rdbms() -> str:
+    if ENV_RDBMS not in os.environ:
+        raise EnvironmentError(f"Environment variable '{ENV_RDBMS}' not set")
+    return os.environ[ENV_RDBMS]
+
+
+URI_RDBMS = get_env_rdbms()
+IS_SQLITE = URI_RDBMS.startswith("sqlite")
+IS_POSTGRES = URI_RDBMS.startswith("postgres")
+HAS_AZURE_BLOB_STORAGE = ENV_BLOB in os.environ
+BLOB_CONTAINER = os.getenv(ENV_BLOB_CONTAINER, "ert")
+
+
+if IS_SQLITE:
+    engine = create_engine(URI_RDBMS, connect_args={"check_same_thread": False})
+else:
+    engine = create_engine(URI_RDBMS, pool_size=50, max_overflow=100)
+Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
 Base = declarative_base()
 
 
 async def get_db(*, _: None = Depends(security)) -> Any:
-    db = database_config.Session()
+    db = Session()
 
     # Make PostgreSQL return float8 columns with highest precision. If we don't
     # do this, we may lose up to 3 of the least significant digits.
-    if database_config.IS_POSTGRES:
+    if IS_POSTGRES:
         db.execute("SET extra_float_digits=3")
     try:
         yield db
@@ -88,13 +52,13 @@ async def get_db(*, _: None = Depends(security)) -> Any:
         raise
 
 
-if database_config.HAS_AZURE_BLOB_STORAGE:
+if HAS_AZURE_BLOB_STORAGE:
     import asyncio
     from azure.core.exceptions import ResourceNotFoundError
     from azure.storage.blob.aio import ContainerClient
 
     azure_blob_container = ContainerClient.from_connection_string(
-        os.environ[database_config.ENV_BLOB], database_config.BLOB_CONTAINER
+        os.environ[ENV_BLOB], BLOB_CONTAINER
     )
 
     async def create_container_if_not_exist() -> None:

--- a/src/ert_storage/database_schema/record.py
+++ b/src/ert_storage/database_schema/record.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import sqlalchemy as sa
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from ert_storage.ext.sqlalchemy_arrays import FloatArray
 from ert_storage.ext.uuid import UUID

--- a/src/ert_storage/endpoints/_records_blob.py
+++ b/src/ert_storage/endpoints/_records_blob.py
@@ -1,17 +1,21 @@
+import io
 from typing import Optional, List, Type, AsyncGenerator
 from uuid import uuid4, UUID
 
+import numpy as np
+import pandas as pd
 from fastapi import (
     Request,
     UploadFile,
     Depends,
 )
+from fastapi.logger import logger
 from fastapi.responses import Response, StreamingResponse
 
 from ert_storage import database_schema as ds
-from ert_storage.database import Session, get_db, database_config
+from ert_storage.database import Session, get_db, HAS_AZURE_BLOB_STORAGE
 
-if database_config.HAS_AZURE_BLOB_STORAGE:
+if HAS_AZURE_BLOB_STORAGE:
     from ert_storage.database import azure_blob_container
 
 
@@ -158,7 +162,7 @@ def get_blob_handler(
     realization_index: Optional[int] = None,
 ) -> BlobHandler:
     blob_handler: Type[BlobHandler]
-    if database_config.HAS_AZURE_BLOB_STORAGE:
+    if HAS_AZURE_BLOB_STORAGE:
         blob_handler = AzureBlobHandler
     else:
         blob_handler = BlobHandler
@@ -169,7 +173,7 @@ def get_blob_handler(
 
 def get_blob_handler_from_record(db: Session, record: ds.Record) -> BlobHandler:
     blob_handler: Type[BlobHandler]
-    if database_config.HAS_AZURE_BLOB_STORAGE:
+    if HAS_AZURE_BLOB_STORAGE:
         blob_handler = AzureBlobHandler
     else:
         blob_handler = BlobHandler

--- a/src/ert_storage/endpoints/responses.py
+++ b/src/ert_storage/endpoints/responses.py
@@ -1,11 +1,12 @@
-from uuid import UUID
+from uuid import uuid4, UUID
 import pandas as pd
 from fastapi import (
     APIRouter,
     Depends,
 )
 from fastapi.responses import Response
-from ert_storage.database import Session, get_db
+from pandas.core.frame import DataFrame
+from ert_storage.database import Session, get_db, HAS_AZURE_BLOB_STORAGE
 from ert_storage import database_schema as ds
 
 router = APIRouter(tags=["response"])

--- a/src/ert_storage/ext/sqlalchemy_arrays.py
+++ b/src/ert_storage/ext/sqlalchemy_arrays.py
@@ -10,7 +10,7 @@ does it internally for its other types.
 from typing import Optional, Type, Union
 import sqlalchemy as sa
 
-from ert_storage.database import database_config
+from ert_storage.database import IS_POSTGRES
 
 import graphene
 from graphene_sqlalchemy.converter import convert_sqlalchemy_type
@@ -24,14 +24,7 @@ SQLAlchemyColumn = Union[sa.types.TypeEngine, Type[sa.types.TypeEngine]]
 FloatArray: SQLAlchemyColumn
 StringArray: SQLAlchemyColumn
 
-# IS_POSTGRES will fail with exception if ENV_DBMS is not available.
-# This module is loaded during compability-check from ERT ( dark-storage api /
-# ert-storage api ) and we need it to complete the loading without exception. It
-# make no sense setting an environment variable in ERT when testing to specify which
-# database is to be used when dark-storage is backed by no database at all. To
-# achieve this we are checking if ENV_DBMS is available. The API itself should not
-# change depending on which database is implemented so this should not be a problem.
-if database_config.ENV_RDBMS_AVAILABLE and database_config.IS_POSTGRES:
+if IS_POSTGRES:
     FloatArray = sa.ARRAY(sa.FLOAT)
     StringArray = sa.ARRAY(sa.String)
 else:

--- a/src/ert_storage/testing/testclient.py
+++ b/src/ert_storage/testing/testclient.py
@@ -5,6 +5,7 @@ from typing import (
     AsyncGenerator,
     Generator,
     Mapping,
+    MutableMapping,
     Optional,
     TYPE_CHECKING,
     Tuple,
@@ -19,6 +20,11 @@ from starlette.testclient import (
     TestClient as StarletteTestClient,
     ASGI2App,
     ASGI3App,
+    Cookies,
+    Params,
+    DataType,
+    TimeOut,
+    FileType,
 )
 from sqlalchemy.orm import sessionmaker
 from graphene import Schema as GrapheneSchema
@@ -191,7 +197,7 @@ def _override_get_db(session: sessionmaker) -> None:
     from ert_storage.app import app
     from ert_storage.database import (
         get_db,
-        database_config,
+        IS_POSTGRES,
     )
 
     async def override_get_db(
@@ -201,7 +207,7 @@ def _override_get_db(session: sessionmaker) -> None:
 
         # Make PostgreSQL return float8 columns with highest precision. If we don't
         # do this, we may lose up to 3 of the least significant digits.
-        if database_config.IS_POSTGRES:
+        if IS_POSTGRES:
             db.execute("SET extra_float_digits=3")
         try:
             yield db
@@ -216,19 +222,23 @@ def _override_get_db(session: sessionmaker) -> None:
 
 
 def _begin_transaction() -> _TransactionInfo:
-    from ert_storage.database import database_config
+    from ert_storage.database import (
+        engine,
+        IS_SQLITE,
+        HAS_AZURE_BLOB_STORAGE,
+    )
     from ert_storage.database_schema import Base
 
-    if database_config.IS_SQLITE:
-        Base.metadata.create_all(bind=database_config.engine)
-    if database_config.HAS_AZURE_BLOB_STORAGE:
+    if IS_SQLITE:
+        Base.metadata.create_all(bind=engine)
+    if HAS_AZURE_BLOB_STORAGE:
         import asyncio
         from ert_storage.database import create_container_if_not_exist
 
         loop = asyncio.get_event_loop()
         loop.run_until_complete(create_container_if_not_exist())
 
-    connection = database_config.engine.connect()
+    connection = engine.connect()
     transaction = connection.begin()
     session = sessionmaker(autocommit=False, autoflush=False, bind=connection)
 

--- a/tests/integration/compute/test_misfits_endpoints.py
+++ b/tests/integration/compute/test_misfits_endpoints.py
@@ -1,4 +1,5 @@
 import io
+from fastapi import params
 import numpy as np
 from numpy.testing import assert_array_equal
 import pandas as pd

--- a/tests/integration/test_azure_storage.py
+++ b/tests/integration/test_azure_storage.py
@@ -7,9 +7,9 @@ def azure_client():
     """
     A synchronous Azure Blob Storage ContainerClient
     """
-    from ert_storage.database import database_config
+    from ert_storage.database import HAS_AZURE_BLOB_STORAGE, ENV_BLOB, BLOB_CONTAINER
 
-    if not database_config.HAS_AZURE_BLOB_STORAGE:
+    if not HAS_AZURE_BLOB_STORAGE:
         pytest.skip("An Azure Storage connection is required to run these tests")
 
     import asyncio
@@ -19,9 +19,7 @@ def azure_client():
     loop = asyncio.get_event_loop()
     loop.run_until_complete(create_container_if_not_exist())
 
-    yield ContainerClient.from_connection_string(
-        os.environ[database_config.ENV_BLOB], database_config.BLOB_CONTAINER
-    )
+    yield ContainerClient.from_connection_string(os.environ[ENV_BLOB], BLOB_CONTAINER)
 
 
 def test_blob(client, azure_client, simple_ensemble):

--- a/tests/integration/test_record_infos.py
+++ b/tests/integration/test_record_infos.py
@@ -1,4 +1,5 @@
 import io
+import numpy
 from fastapi import status
 
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -15,7 +15,7 @@ def test_help_missing_env_rdbms(monkeypatch):
     with pytest.raises(Exception) as e:
         from ert_storage import database
 
-        database.database_config.get_env_rdbms()
+        database.get_env_rdbms()
 
     assert str(e.value) == "Environment variable 'ERT_STORAGE_DATABASE_URL' not set"
 
@@ -26,6 +26,6 @@ def test_help_with_env_rdbms(monkeypatch):
 
     from ert_storage import database
 
-    act_rdbms = database.database_config.get_env_rdbms()
+    act_rdbms = database.get_env_rdbms()
 
     assert db_url == act_rdbms


### PR DESCRIPTION
This reverts commit c0fc0faf947123daaa3cfa46c4f16c7836a05409.

The introduction of lazy loading is flaky and seems to fail at random points where we loose session or engine. For the time being it is hard to debug and the reason for the introduction of lazy loading itself is not worth spending more time on for now. Maybe we will pick up again on the issue where we need to set the database url in an environment variable if needed.