### PR TITLE
Set temporary upper limit of graphene

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "async-exit-stack; python_version < '3.7'",
         "async-generator; python_version < '3.7'",
         "fastapi",
-        "graphene",
+        "graphene<3.0.0",
         "graphene-sqlalchemy>=2.0",
         "numpy",
         "pandas",


### PR DESCRIPTION
New version of graphene causes issues.
This should be removed once issues are solve

Getting errors that I think might have something to do with the newest release of graphene.

![Screenshot 2021-11-15 at 08 43 27](https://user-images.githubusercontent.com/45088507/141777142-070aab40-0adf-4b95-b19b-f1da045e08da.png)
d.