### PR TITLE
Increase timeout on server startup in intergration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,7 +29,7 @@ def server(auth):
 
     # Using a sleep to wait for server start is too fragile, but not much
     # other choice that is lightweight
-    time.sleep(2)
+    time.sleep(30)
     # Check it started successfully
     assert not server_proc.poll(), server_proc.stdout.read().decode("utf-8")
     yield server_proc


### PR DESCRIPTION
# Issue
Resolves #2442

Integration tests in CI are flaky due to the sleep based  wait mechanism used when starting an instance of err-storage

As short term fix increase the sleep time.


