### PR TITLE
Get records by name as "ensemble wide" records

### DIFF
--- a/src/ert_storage/endpoints/records.py
+++ b/src/ert_storage/endpoints/records.py
@@ -539,7 +539,12 @@ async def get_ensemble_record(
         data_df = _get_record_dataframe(record, realization_index, label)
         df_list.append(data_df)
 
-    return await _get_record_resonse(pd.concat(df_list, axis=0), accept)
+    # Combine data for each realization into one dataframe
+    data_frame = pd.concat(df_list, axis=0)
+    # Sort data by realization number
+    data_frame.sort_index(axis=0, inplace=True)
+
+    return await _get_record_resonse(data_frame, accept)
 
 
 @router.get("/ensembles/{ensemble_id}/records/{name}/labels", response_model=List[str])

--- a/tests/integration/spe1_st/test_load_data.py
+++ b/tests/integration/spe1_st/test_load_data.py
@@ -87,5 +87,5 @@ def test_read_responses(requests_get, get_ensemble_id):
         ).json()
 
         # test the data size
-        assert len(response_real_0[0]) == 108
-        assert len(response_real_1[0]) == 108
+        assert len(response_real_0) == 108
+        assert len(response_real_1) == 108


### PR DESCRIPTION
Support getting "ensemble wide" records when getting record data by name only. 

This means that if a client adds to ert storage record _indexed_data_ as:

```python
>> client.post(
        url=f"/ensembles/{ensemble_id}/records/indexed_data",
            data= pd.DataFrame([0.1,0.2,0.3]).to_csv().encode(),
            headers={"content-type": "text/csv"},
            params=dict(realization_index=0),
    )

>> client.post(
        url=f"/ensembles/{ensemble_id}/records/indexed_data",
            data= pd.DataFrame([3.1,3.2,3.3]).to_csv().encode(),
            headers={"content-type": "text/csv"},
            params=dict(realization_index=3),
    )
```

Then when retrieving data from storage it will be possible to just get the ensemble wide record by name:

```python
>> resp = client.get(
        url=f"/ensembles/{ensemble_id}/records/indexed_data",
            headers={"content-type": "application/json"},
    )

>> resp.json

[[0.1, 0.2, 0,3], [3.1, 3.2, 3.3]]

```