### PR TITLE
Publish to pypi using statoil-travis token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,5 +25,6 @@ jobs:
       - name: Upload
         uses: pypa/gh-action-pypi-publish@v1.3.1
         with:
-          user: statoil-travis
+          user: __token__
           password: ${{ secrets.pypi_password }}
+


### PR DESCRIPTION
Use statoil-travis token when publishing to pypi