### PR TITLE
Pin fastapi to 0.70.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "alembic",
         "async-exit-stack; python_version < '3.7'",
         "async-generator; python_version < '3.7'",
-        "fastapi",
+        "fastapi==0.70.1",
         "graphene<3.0.0",
         "graphene-sqlalchemy>=2.0",
         "httpx",


### PR DESCRIPTION
The newest fastapi broke our code. 

**Issue**
The latest fastapi is not compatible with ert-storage. Therefore pinning the version. 
The long-term solution would be to replace graphql usage from starlette by another 3rd party library: https://www.starlette.io/graphql/


