### PR TITLE
Make black test only for >= Python 3.8

### DIFF
--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -4,6 +4,9 @@ from subprocess import run
 
 
 def test_formatting():
+    if sys.version_info < (3, 8):
+        return
+
     proc = run(
         [
             sys.executable,


### PR DESCRIPTION
**Issue**
Black is no longer compatible with Python 3.6, so test_formatting should be done only for Python 3.8 and bigger.


**Approach**
Check the python version and run the test only when version matches


