### PR TITLE
Add long description to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
 from setuptools import setup
 
+with open("README.md") as f:
+    long_description = f.read()
+
 
 setup(
     name="ert-storage",
     description="Storage service for ERT",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author="Equinor ASA",
     author_email="fg_sib-scout@equinor.com",
     url="https://github.com/equinor/ert-storage",


### PR DESCRIPTION
**Issue**
The github action to publish a release to pypi has stopped working,  seems to be an issue with missing `long_description` from `setup.py`


**Approach**
Add `long_description` and `long_description_content_type` to `setup.py`

