### PR TITLE
Add property experiment_id on ensemble model

### DIFF
--- a/src/ert_storage/database_schema/ensemble.py
+++ b/src/ert_storage/database_schema/ensemble.py
@@ -51,3 +51,7 @@ class Ensemble(Base, UserdataField):
     @property
     def child_ensemble_ids(self) -> List[PyUUID]:
         return [x.ensemble_result.id for x in self.children]
+
+    @property
+    def experiment_id(self) -> PyUUID:
+        return self.experiment.id


### PR DESCRIPTION
**Issue**
webviz-ert is using `experiment_id` on the ensemble-model from the graphql endpoints. Removing these endpoints as decided and only utilize REST this will cause an error as we are not exposing the needed property on the model in question. 


**Approach**
Instead of refactoring across different repos, i'm adding the missing property to the model as this should not cause any overhead. 


