### PR TITLE
Update location of ert services

### DIFF
--- a/tests/integration/spe1_st/conftest.py
+++ b/tests/integration/spe1_st/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 @pytest.fixture(scope="session")
 def get_info():
-    from ert.shared.services import Storage
+    from ert.services import Storage
 
     with Storage.start_server() as service:
         yield service.fetch_url(), service.fetch_auth()[1]


### PR DESCRIPTION
The location of ert services has moved in ert=4.0.0-b0. This updates the path which is used only in the spe1 integration test. It seems `ert-storage` runs the spe1 integration test on whatever is deployed in komodo bleeding, so the timing of this merge depends on the state of what is deployed.

