### PR TITLE
Register pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,7 @@ requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel"]
 [tool.setuptools_scm]
 
 [tool.pytest.ini_options]
-addopts = "-k 'not spe1'"
+addopts = "-k 'not spe1' --strict-markers"
+markers = [
+    "spe1"
+]


### PR DESCRIPTION
This avoids pytest printing warnings about unregistered markers in its output.

Markers are now enforced to be registered through the --strict-markers option.
