### PR TITLE
Pin fastapi<0.89 due to changes in Response

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     },
     install_requires=[
         "alembic",
-        "fastapi",
+        "fastapi<0.89",
         "httpx",
         "numpy",
         "pandas",


### PR DESCRIPTION
**Issue**
Changes in fastapi 0.89 causing following error 
```
fastapi.exceptions.FastAPIError: Invalid args for response field! Hint: check that <class 'starlette.responses.Response'> is a valid pydantic field type
Error: Process completed with exit code 1.
```


**Approach**
Pinning it for now and created an issue #232 


